### PR TITLE
[PATCH] Removes logout block from template

### DIFF
--- a/development/templates/development/match_detail.html
+++ b/development/templates/development/match_detail.html
@@ -11,6 +11,3 @@
 
 <hr>
 {% endblock %}
-
-{% block logout_modal %}
-{% endblock logout_modal%}

--- a/development/templates/development/match_history.html
+++ b/development/templates/development/match_history.html
@@ -13,6 +13,3 @@
 
 <hr>
 {% endblock %}
-
-{% block logout_modal %}
-{% endblock logout_modal%}

--- a/development/templates/development/my_bots.html
+++ b/development/templates/development/my_bots.html
@@ -20,6 +20,3 @@
 
 
 {% endblock %}
-
-{% block logout_modal %}
-{% endblock logout_modal%}


### PR DESCRIPTION
The problem was these lines in templates.
```
{% block logout_modal %}
{% endblock logout_modal %}
```
This was disabling the logout button.