### PR TITLE
[PATCH] EDA-1413 Restrict names only to letters and numbers

### DIFF
--- a/development/forms.py
+++ b/development/forms.py
@@ -5,6 +5,7 @@ from .bot_handler import (
     get_my_bots,
 )
 from auth_app.models import Bot
+import re
 
 
 class ChallengeForm(forms.Form):
@@ -23,6 +24,14 @@ class ChallengeForm(forms.Form):
 
 
 class BotForm(forms.ModelForm):
+    name = forms.CharField(required=True)
+
     class Meta:
         model = Bot
         fields = ('name',)
+
+    def clean_name(self, *args, **kwargs):
+        name = self.cleaned_data.get('name')
+        if not re.match("[A-Za-z0-9]*$", name):
+            raise forms.ValidationError('Name cannot contains symbols or spaces')
+        return name

--- a/development/tests/test_bot_form.py
+++ b/development/tests/test_bot_form.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+from development.forms import BotForm
+from parameterized import parameterized
+
+
+class AddBotFormTest(TestCase):
+    @parameterized.expand([
+        ['letters', {'name': 'adsajdqwhjhwqje'}],
+        ['numbers', {'name': '12343534'}],
+        ['letters_and_numbers', {'name': 'thsjh3j412932hj'}],
+    ])
+    def test_bot_name_correct_input_data(
+        self,
+        _test_name,
+        data,
+    ):
+        bot_form = BotForm(data=data)
+
+        self.assertEqual(
+            bot_form.errors,
+            {},
+        )
+
+    def test_it_should_return_error_when_bot_name_contains_symbols(self):
+        bot_form = BotForm(data={'name': 'asdas!@#@3213'})
+
+        self.assertEqual(
+            bot_form.errors['name'],
+            ['Name cannot contains symbols or spaces'],
+        )


### PR DESCRIPTION
Bot names can only contain letters and numbers.