### PR TITLE
The serializer now requires tournament_id

### DIFF
--- a/development/serializer.py
+++ b/development/serializer.py
@@ -12,7 +12,8 @@ class MatchSerializer(serializers.ModelSerializer):
             'bot_2',
             'score_p_1',
             'score_p_2',
-            'game_id'
+            'game_id',
+            'tournament_id',
         ]
 
     def create(self, validated_data):

--- a/development/tests/test_views_api.py
+++ b/development/tests/test_views_api.py
@@ -25,7 +25,8 @@ class Tests(TestCase):
             'user_1': self.user1.id,
             'bot_2': self.bot2.id,
             'score_p_2': 1000,
-            'user_2': self.user2.id
+            'user_2': self.user2.id,
+            'tournament_id': '',
         }
         self.dict['data_not_found'] = None
 
@@ -44,18 +45,30 @@ class Tests(TestCase):
         r = responde.status_code
         self.assertEqual(status, r)
 
-    @parameterized.expand([
-        [{'game_id': '1111', 'data': [('bot1', 2000), ('bot2', 1000)]}],
-    ])
-    def test_convert_data_ok(self, data):
+    def test_convert_data_ok(self):
         dic1 = self.dict['correct_response']
-        dic2 = convert_data(data)
+        dic2 = convert_data(
+            {
+                'game_id': '1111',
+                'data': [
+                    ('bot1', 2000),
+                    ('bot2', 1000)
+                ],
+                'tournament_id': '',
+            }
+        )
 
         self.assertEqual(dic1, dic2)
 
-    @parameterized.expand([
-        [{'game_id': '1111', 'date': [('bot1', 2000), ('bot2', 1000)]}],
-    ])
-    def test_convert_data_wrong(self, data):
+    def test_convert_data_wrong(self):
         with self.assertRaises(KeyError):
-            convert_data(data)
+            convert_data(
+                {
+                    'game_id': '1111',
+                    'date': [
+                        ('bot1', 2000),
+                        ('bot2', 1000)
+                    ],
+                    'tournament_id': '',
+                },
+            )

--- a/development/views_api.py
+++ b/development/views_api.py
@@ -39,6 +39,7 @@ def convert_data(req_data):
     """ Recieve a dictionary and return a new dictionary. """
     data = {}
     data['game_id'] = req_data["game_id"]
+    data['tournament_id'] = req_data['tournament_id']
     for i, (name, score) in enumerate(req_data["data"], 1):
         bot = Bot.objects.filter(name=name)[0]
         data[f'bot_{i}'] = bot.id


### PR DESCRIPTION
All matches must have a tournament_id. This allows filtering for matches of a tournament.

NOTE: If it is a normal match tournament_id will be empty ' '.