### PR TITLE
[PATCH]The main bot cannot be deleted

### DIFF
--- a/auth_app/urls.py
+++ b/auth_app/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
     ),
     path('register/', Registration.as_view(), name='register'),
 
-    path('profile/<pk>/', Profile.as_view(template_name='auth_app/profile.html'), name='profile'),
+    path('profile/', Profile.as_view(template_name='auth_app/profile.html'), name='profile'),
     path('faq/', FAQ.as_view(template_name='auth_app/faq.html'), name='faq'),
 ]

--- a/auth_app/views.py
+++ b/auth_app/views.py
@@ -24,7 +24,8 @@ class Registration(FormView):
 
 
 class Profile(LoginRequiredMixin, DetailView):
-    queryset = User.objects.all()
+    def get_object(self):
+        return User.objects.get(id=self.request.user.id)
 
 
 class FAQ(LoginRequiredMixin, generic.TemplateView):

--- a/auth_app/views.py
+++ b/auth_app/views.py
@@ -4,7 +4,6 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views import generic
 from django.urls import reverse_lazy
 
-from .models import User
 from .forms import UserRegisterForm
 
 
@@ -25,7 +24,7 @@ class Registration(FormView):
 
 class Profile(LoginRequiredMixin, DetailView):
     def get_object(self):
-        return User.objects.get(id=self.request.user.id)
+        return self.request.user
 
 
 class FAQ(LoginRequiredMixin, generic.TemplateView):

--- a/development/templates/development/my_bots.html
+++ b/development/templates/development/my_bots.html
@@ -20,7 +20,9 @@
               <td width="73%" class="text-break">{{ bot.token}}</td>
               <td>
                 <form action = "{% url 'development:delete_bot' pk=bot.id %}" method = "post">{% csrf_token %}
-                <input type="submit" class="btn btn-secondary" value="delete">
+                  {% if not forloop.first %}
+                  <input type="submit" class="btn btn-secondary" value="delete">
+                  {% endif %}
                 </form>
               </td>
             </tr>

--- a/development/tests/test_delete_bot.py
+++ b/development/tests/test_delete_bot.py
@@ -1,24 +1,22 @@
-from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.test import TestCase
+
 from auth_app.models import Bot
 
 
 class TestDeleteBot(TestCase):
-
-    def setUp(self):
-        self.user = get_user_model().objects.create_user(
-            "test_user",
-            "test_user@email.com",
-            "my_pass",
-        )
-        self.client.force_login(self.user)
-
     def test_should_return_302_when_user_makes_a_request(
         self,
     ):
+        user = get_user_model().objects.create_user(
+            username="test_user",
+            email="test_user@email.com",
+            password="my_pass",
+        )
+        self.client.force_login(user)
         Bot.objects.create(
             name='test_bot1',
-            user=self.user,
+            user=user,
         )
         response = self.client.post('/bots/1/delete')
         self.assertEqual(
@@ -31,16 +29,49 @@ class TestDeleteBot(TestCase):
         )
 
     def test_should_delete_the_selected_bot_when_a_user_press_delete(self):
-        Bot.objects.create(
+        user = get_user_model().objects.create_user(
+            username="test_user",
+            email="test_user@email.com",
+            password="my_pass",
+        )
+        self.client.force_login(user)
+        bot = Bot.objects.create(
             name='test_bot1',
-            user=self.user,
+            user=user,
         )
         self.assertEqual(
-            len(Bot.objects.filter(id=self.user.id)),
+            len(Bot.objects.filter(id=user.id)),
             1,
         )
-        self.client.post('/bots/1/delete')
-        self.assertEqual(
-            len(Bot.objects.filter(id=self.user.id)),
-            0,
+        response = self.client.post('/bots/{bot_id}/delete'.format(bot_id=bot.id))
+        messages = [str(msg) for msg in response.wsgi_request._messages]
+        self.assertIn('Bot successfully removed', messages)
+        with self.assertRaises(Bot.DoesNotExist):
+            Bot.objects.get(pk=bot.id)
+
+    def test_should_not_allow_delete_official_bot(self):
+        user = get_user_model().objects.create_user(
+            username="test_official_bot",
+            email="test_official_bot@email.com",
+            password="my_pass",
         )
+        self.client.force_login(user)
+        bot = Bot.objects.create(
+            name='test_official_bot@email.com',
+            user=user,
+        )
+        response = self.client.post('/bots/{bot_id}/delete'.format(bot_id=bot.id))
+        messages = [str(msg) for msg in response.wsgi_request._messages]
+        self.assertIn('The official bot cannot be removed', messages)
+        Bot.objects.get(pk=bot.id)
+
+    def test_should_raise_error_when_delete_if_bot_not_exists(self):
+        user = get_user_model().objects.create_user(
+            username="test_bot_not_exists",
+            email="test_bot_not_exists@email.com",
+            password="my_pass",
+        )
+        self.client.force_login(user)
+        response = self.client.post('/bots/99/delete')
+        messages = [str(msg) for msg in response.wsgi_request._messages]
+        self.assertIn('The bot does not exists', messages)

--- a/development/views.py
+++ b/development/views.py
@@ -144,10 +144,25 @@ class AddBotView(FormView):
 
 @require_http_methods(["POST"])
 def delete_bot(request, pk):
-    Bot.objects.get(id=pk).delete()
-    messages.add_message(
-        request,
-        messages.SUCCESS,
-        'Bot successfully removed'
-    )
+    try:
+        bot = Bot.objects.get(id=pk)
+        if request.user.email != bot.name:
+            bot.delete()
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                'Bot successfully removed'
+            )
+        else:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                'The official bot cannot be removed'
+            )
+    except Bot.DoesNotExist:
+        messages.add_message(
+            request,
+            messages.ERROR,
+            'The bot does not exists'
+        )
     return redirect('development:mybots')

--- a/templates/base.html
+++ b/templates/base.html
@@ -112,7 +112,7 @@
                             <!-- Dropdown - User Information -->
                             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="userDropdown">
-                                <a class="dropdown-item" href="{% url 'auth:profile' user.id %}">
+                                <a class="dropdown-item" href="{% url 'auth:profile' %}">
                                     <i class="fas fa-cogs fa-sm fa-fw mr-2 text-gray-400"></i>
                                     Profile
                                 <div class="dropdown-divider"></div>


### PR DESCRIPTION
The main bot will be used in tournaments so, anyone can delete this bot.

Remove the `delete` option for the first item from the table
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/80478831/161113143-e6974c7a-87ed-4a79-958e-4fdf2949b15a.png">
