### PR TITLE
[PATCH]Cannot mock get_logs function

### DIFF
--- a/development/common/match_utils.py
+++ b/development/common/match_utils.py
@@ -3,6 +3,7 @@ from development.models import (
     Match,
     MatchMembers,
 )
+from development.server_requests import get_logs
 
 
 def get_matches_of_connected_user(user):
@@ -58,3 +59,26 @@ def get_match_players(match_id, match_members):
         for match_member in match_members
         if match_member.match.id == match_id
     ]
+
+
+def get_all_logs_for_match(game_id):
+    data_logs = []
+    page_logs = get_page_logs_for_match(game_id, page_token=None)
+    data_logs.append(page_logs["logs"])
+    page_token = page_logs["next_token"]
+    while page_token:
+        get_page_logs_for_match(game_id, page_token)
+    return data_logs
+
+
+def get_page_logs_for_match(game_id, page_token):
+    response = get_logs(
+        game_id=game_id,
+        page_token=page_token,
+    )
+    response_data = response.json()
+    page_token = response_data['next']
+    return {
+        "logs": response_data['details'],
+        "next_token": page_token
+    }

--- a/development/templates/development/match_details.html
+++ b/development/templates/development/match_details.html
@@ -40,6 +40,10 @@
     <div class="form-row">
         <span class="mx-auto">
             <a class="btn btn-primary" href="{% url 'development:match_details' pk=object.id %}?page={{prev_page}}" role="button"><<</a>
+            <a href="?page=1">&laquo; first</a>
+            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+            <a href="?page={{ page_obj.next_page_number }}">next</a>
+            <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
             <a class="btn btn-primary" href="{% url 'development:match_details' pk=object.id %}?page={{next_page}}" role="button">>></a>
         </span>
     </div>

--- a/development/tests/test_match_details.py
+++ b/development/tests/test_match_details.py
@@ -1,14 +1,19 @@
-from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.test import TestCase
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from auth_app.models import Bot
 from development.models import (
     Match,
     MatchMembers,
 )
 from development.views import MatchDetailsView
-from auth_app.models import Bot
-from unittest.mock import patch
-from unittest.mock import MagicMock
-import json
+
+from development.common.match_utils import (
+    get_page_logs_for_match,
+)
 
 
 class TestMatchDetailsView(TestCase):
@@ -98,4 +103,25 @@ class TestMatchDetailsView(TestCase):
         self.assertEquals(
             response.context_data['data'],
             'testing'
+        )
+
+
+class TestMatchUtils(TestCase):
+    @patch('development.server_requests.get_logs')
+    def test_should_return_first_log_page(self, mocked_get_logs):
+        mocked_get_logs.json.return_value = {
+            "details": ['log1', 'log2'],
+            "next": 'asdkj1i3182ue9wuq9ejqkw912831'
+        }
+        first_page_logs = get_page_logs_for_match(
+            game_id="klklewdhjasjd1238u1",
+            page_token=None
+        )
+
+        self.assertEqual(
+            first_page_logs,
+            {
+                "logs": ['log1', 'log2'],
+                "next_token": 'asdkj1i3182ue9wuq9ejqkw912831'
+            }
         )


### PR DESCRIPTION
In order to navigate through all match logs, there is needed a pagination.

Plan:
- Get all logs iterating until there is no more token to get all redis pages.
- Paginate the log list every 20 items.
- Add buttons to navigate through pages.

![image](https://user-images.githubusercontent.com/80478831/162524378-0be655d9-3b6e-4544-9d82-98da228ffac4.png)
