### PR TITLE
[MINOR] Fix tournament details view

### DIFF
--- a/development/constants.py
+++ b/development/constants.py
@@ -1,0 +1,3 @@
+LOSS = 0
+TIE = 1
+WIN = 2

--- a/tournaments/common/tournament_utils.py
+++ b/tournaments/common/tournament_utils.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import List
 
 from django.db.models import (
@@ -36,23 +37,24 @@ def get_tournament_results(tournament_id: int) -> List[dict]:
 def calculate_match_results_by_player():
     match_members_results = MatchMembers.objects.values_list(
         "bot__name",
-        "match_result").filter(match__tournament=2).annotate(Count("bot_id"))
-    results = {}
+        "match_result",
+    ).filter(match__tournament=2).annotate(Count("bot_id"))
+
+    results = defaultdict(lambda: {
+        "total_match": 0,
+        "total_match_won": 0,
+        "total_match_tied": 0,
+        "total_match_lost": 0,
+        "total_score": 0,
+    })
     for bot_name, match_result, quantity in match_members_results:
-        if not results.get(bot_name):
-            results[bot_name] = {
-                "total_match": 0,
-                "total_match_won": 0,
-                "total_match_tied": 0,
-                "total_match_lost": 0,
-                "total_score": 0,
-            }
         if match_result == WIN:
-            results[bot_name]["total_match_won"] = quantity
+            total_key = "total_match_won"
         elif match_result == TIE:
-            results[bot_name]["total_match_tied"] = quantity
+            total_key = "total_match_tied"
         elif match_result == LOSS:
-            results[bot_name]["total_match_lost"] = quantity
+            total_key = "total_match_lost"
+        results[bot_name][total_key] = quantity
     return results
 
 

--- a/tournaments/common/tournament_utils.py
+++ b/tournaments/common/tournament_utils.py
@@ -1,0 +1,84 @@
+from typing import List
+
+from django.db.models import (
+    Count,
+    Sum,
+)
+
+from development.constants import (
+    LOSS,
+    TIE,
+    WIN,
+)
+from development.models import MatchMembers
+
+
+def get_tournament_results(tournament_id: int) -> List[dict]:
+    """
+    This method receives a tournament id and returns a list of dictionaries for each bot
+    that has participated in the tournament.
+    {
+        bot name: {
+            "total_match": the number of matches played:
+            "total_match_won": the number of matches won:
+            "total_match_tied": the number of matches tied:
+            "total_match_lost": the number of matches lost:
+            "total_score": the sum of scores made in all matches
+        }
+    }
+    """
+    results = calculate_match_results_by_player()
+    results = add_score_to_results_and_total_matches(results)
+
+    return results
+
+
+def calculate_match_results_by_player():
+    match_members_results = MatchMembers.objects.values_list(
+        "bot__name",
+        "match_result").filter(match__tournament=2).annotate(Count("bot_id"))
+    results = {}
+    for bot_name, match_result, quantity in match_members_results:
+        if not results.get(bot_name):
+            results[bot_name] = {
+                "total_match": 0,
+                "total_match_won": 0,
+                "total_match_tied": 0,
+                "total_match_lost": 0,
+                "total_score": 0,
+            }
+        if match_result == WIN:
+            results[bot_name]["total_match_won"] = quantity
+        elif match_result == TIE:
+            results[bot_name]["total_match_tied"] = quantity
+        elif match_result == LOSS:
+            results[bot_name]["total_match_lost"] = quantity
+    return results
+
+
+def add_score_to_results_and_total_matches(results):
+    match_members_results = MatchMembers.objects.values_list(
+        'bot__name',
+        Sum('score')).filter(match__tournament=2).annotate(Count('score'))
+    for bot_name, total_score, total_match in match_members_results:
+        results[bot_name]["total_match"] = total_match
+        results[bot_name]["total_score"] = total_score
+    return results
+
+
+def sort_position_table(table):
+    table = convert_dict_to_tuples(table)
+    return sorted(table, key=lambda x: (x[2], x[5], x[3]), reverse=True)
+
+
+def convert_dict_to_tuples(table):
+    return [
+        (
+            bot_name,
+            match_result["total_match"],
+            match_result["total_match_won"],
+            match_result["total_match_tied"],
+            match_result["total_match_lost"],
+            match_result["total_score"],
+        ) for bot_name, match_result in table.items()
+    ]

--- a/tournaments/templates/tournaments/tournament_results.html
+++ b/tournaments/templates/tournaments/tournament_results.html
@@ -13,26 +13,32 @@
             <th scope="col">Player</th>
             <th scope="col">Total Match</th>
             <th scope="col">Total Wins</th>
+            <th scope="col">Total Ties</th>
+            <th scope="col">Total Losses</th>
             <th scope="col">Total Score</th>
           </tr>
         </thead>
         <tbody>
         {% for match in object_list %}
-            {% if forloop.counter < 4 %}
+            {% if forloop.first %}
                 <tr class="bg-success text-white">
                     <td>{{ forloop.counter }}</td>
-                    <td>{{ match.bot }}</td>
-                    <td>{{ match.total_match }}</td>
-                    <td>{{ match.total_match_won }}</td>
-                    <td>{{ match.total_score }}</td>
+                    <td>{{ match.0 }}</td>
+                    <td>{{ match.1 }}</td>
+                    <td>{{ match.2 }}</td>
+                    <td>{{ match.3 }}</td>
+                    <td>{{ match.4 }}</td>
+                    <td>{{ match.5 }}</td>
                 </tr>
             {% else %}
                 <tr>
                     <td>{{ forloop.counter }}</td>
-                    <td>{{ match.bot }}</td>
-                    <td>{{ match.total_match }}</td>
-                    <td>{{ match.total_match_won }}</td>
-                    <td>{{ match.total_score }}</td>
+                    <td>{{ match.0 }}</td>
+                    <td>{{ match.1 }}</td>
+                    <td>{{ match.2 }}</td>
+                    <td>{{ match.3 }}</td>
+                    <td>{{ match.4 }}</td>
+                    <td>{{ match.5 }}</td>
                 </tr>
             {% endif %}
         {% endfor %}

--- a/tournaments/tests/test_tournaments.py
+++ b/tournaments/tests/test_tournaments.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
+from parameterized import parameterized
 
 from django.http import HttpResponse
 from django.test import (
     RequestFactory,
     TestCase,
 )
-from parameterized import parameterized
 
 from auth_app.models import (
     Bot,

--- a/tournaments/views.py
+++ b/tournaments/views.py
@@ -1,8 +1,8 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import (
     LoginRequiredMixin,
     UserPassesTestMixin,
 )
-from django.contrib import messages
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView


### PR DESCRIPTION
Now the Tournament Details table is sorted by the winner with the following priority:
- Wins
- Total Score
- Ties

Also now it's shown the number of tied matches.

![image](https://user-images.githubusercontent.com/80478831/163307630-93433b69-6522-452f-9847-d96cfc355718.png)
_The negative scores are because the bots don't know how to play yet_
