### PR TITLE
Use username (not email) when show available users generating tournaments

### DIFF
--- a/tournaments/templates/tournaments/tournament_generator.html
+++ b/tournaments/templates/tournaments/tournament_generator.html
@@ -10,7 +10,7 @@
             <p>Registered users ({{registrations_count}})</p>
             <ul class="list-group">
                 {% for registration in registrations %}
-                <li class="list-group-item">{{registration.user.email}}</li>
+                <li class="list-group-item">{{registration.user.username}}</li>
                 {% endfor %}
             </ul>
         <br></br>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53191391/165367645-e899d08e-0212-42dd-8a81-a268325b9996.png)
