### PR TITLE
[PATCH][EDA-1734] - Change settings for database in Django

### DIFF
--- a/edagames/settings/prod.py
+++ b/edagames/settings/prod.py
@@ -128,7 +128,7 @@ secret_value = json.loads(get_secret(get_env_variable('DB_SECRET_NAME')))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': secret_value["dbClusterIdentifier"],
+        'NAME': secret_value["dbname"],
         'USER': secret_value["username"],
         'PASSWORD': secret_value["password"],
         'HOST': secret_value["host"],


### PR DESCRIPTION
Inside the configurations of the database, in the attribute name, change the key `dbClusterIdentifier` for `dbname`.