### PR TITLE
[EDA-1759][MINOR] - Add createChampinoship view

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ in the same pwd as the manage.py run
 ```
 python3 manage.py test
 ```
-if you want to see the coverage and generate a html coverage
+if you want to see the coverage and generate a html coverage run
 ```
-coverage run manage.py test && pipenv run coverage xml && pipenv run coverage report -m
+coverage run manage.py test && pipenv run coverage xml && pipenv run coverage report -m && pipenv run coverage html
 ```
 
 ### Problems that you could have

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,6 +72,7 @@
                     <div class="bg-white py-2 collapse-inner rounded">
                         {% if user.is_staff %}
                         <a class="collapse-item" href="{% url 'tournaments:create_tournament' %}">Create Tournament</a>
+                        <a class="collapse-item" href="{% url 'tournaments:create_championship' %}">Genereate Championship</a>
                         <a class="collapse-item" href="{% url 'tournaments:tournament_generator' %}">Generate Tournament</a>
                         <a class="collapse-item" href="{% url 'tournaments:tournaments_pending' %}">Pending Tournaments</a>
                         {% endif %}

--- a/tournaments/forms.py
+++ b/tournaments/forms.py
@@ -16,3 +16,9 @@ class TournamentForm(forms.Form):
 class TournamentGeneratorForm(forms.Form):
     tournament_name = forms.CharField(label='name', required=True)
     max_players = forms.IntegerField(label='maxPlayers', required=True)
+
+
+class ChampionshipGeneratorForm(forms.Form):
+    championship_name = forms.CharField(label='championship name', required=True)
+    finalist_users_per_tournament = forms.IntegerField(label='finalist users per tournament', required=True)
+    max_players = forms.IntegerField(label='max players per tournament', required=True)

--- a/tournaments/templates/tournaments/championship_generator.html
+++ b/tournaments/templates/tournaments/championship_generator.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load bootstrap4 %}
+{% bootstrap_css %}
+{% block page_content %}
+
+<div class="container">
+    <h2>Generate Championship</h2>
+    <form method="POST" class="post-form">{% csrf_token %}
+        {% bootstrap_form form %}
+            <p>Finalist users list ({{registrations_count}})</p>
+            <ul class="list-group">
+                {% for registration in registrations %}
+                <li class="list-group-item">{{registration.user.username}}</li>
+                {% endfor %}
+            </ul>
+        <br></br>
+        <input class="btn btn-primary" type="submit" value="Generate">
+    </form>
+</div>
+{% endblock page_content %}

--- a/tournaments/urls.py
+++ b/tournaments/urls.py
@@ -2,6 +2,7 @@ from django.urls import (
     path,
 )
 from .views import (
+    ChampionshipCreateView,
     CreateTournamentView,
     delete_tournament,
     PendingTournamentListView,
@@ -23,6 +24,11 @@ urlpatterns = [
         'tournaments/<int:pk>/delete',
         delete_tournament,
         name='delete_tournament',
+    ),
+    path(
+        'create_championship/',
+        ChampionshipCreateView.as_view(),
+        name='create_championship',
     ),
     path(
         'tournament_generator/',

--- a/tournaments/views.py
+++ b/tournaments/views.py
@@ -28,6 +28,7 @@ from tournaments.server_requests import (
     start_tournament,
 )
 from tournaments.forms import (
+    ChampionshipGeneratorForm,
     TournamentForm,
     TournamentGeneratorForm,
 )
@@ -209,6 +210,12 @@ class TournamentResultsView(ListView):
 
     def get_queryset(self, *args, **kwargs):
         return sort_position_table(get_tournament_results(self.kwargs.get('pk')))
+
+
+class ChampionshipCreateView(StaffRequiredMixin, FormView):
+    form_class = ChampionshipGeneratorForm
+    success_url = reverse_lazy('tournaments:tournaments_pending')
+    template_name = 'tournaments/championship_generator.html'
 
 
 @require_http_methods(["POST"])


### PR DESCRIPTION


Championship creates a certain amount of tournaments and pics with a specified number of finalists of each tournament create a final tournaments.

<img width="1680" alt="Screen Shot 2022-10-19 at 17 23 51" src="https://user-images.githubusercontent.com/113436342/196796762-29c24a94-2fdb-4e7a-b0de-3831422027b8.png">

this pr also resolves more tickets, by the nature of the problem, its all interconected

[EDA-1759] - the view is just created, it needs to add functionality and testing
[EDA-1762] - added the URL of the view to the url.py file of tournaments
[EDA-1767] - update the class diagram to have the championship class associated with tournaments
[EDA-1768] - added in the menu the generate championship template that is in base.html
[EDA-1761] - a template of the championship is added to the templates of tournaments

also: updated the readme, to show the command need it to generate coverage with an HTML 