### PR TITLE
[PATCH][EDA-1796] Add js test to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,10 @@ version: 2.1
 jobs:
   build-and-test-js:
     docker:
-      - image: cimg/node:14.18.1
+      - image: cimg/node:16.17.0
     steps:
       - checkout
       - run:
-          working_directory: ~/project/javascript_test
           name: update npm
           command: "sudo npm install --unsafe-perm -g npm@latest"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,25 @@
 version: 2.1
 
 jobs:
+  build-and-test-js:
+    docker:
+      - image: cimg/node:14.18.1
+    working_directory: ~/javascript_test
+    steps:
+      - checkout
+      - run:
+          name: update npm
+          command: "sudo npm install --unsafe-perm -g npm@latest"
+      - run:
+          name: install dependencies
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: run space test
+          command: npm test
   build-and-test:
     docker:
       - image: cimg/python:3.8.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,17 @@ jobs:
     docker:
       - image: cimg/node:14.18.1
     steps:
-      - checkout:
-          path: ~/javascript_test
+      - checkout
       - run:
+          working_directory: ~/project/javascript_test
           name: update npm
           command: "sudo npm install --unsafe-perm -g npm@latest"
       - run:
+          working_directory: ~/project/javascript_test
           name: install dependencies
           command: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
       - run:
+          working_directory: ~/project/javascript_test
           name: run space test
           command: npm test
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,11 @@ version: 2.1
 
 jobs:
   build-and-test-js:
-    working_directory: ./javascript_test
     docker:
       - image: cimg/node:14.18.1
     steps:
-      - checkout
+      - checkout:
+          path: ~/javascript_test
       - run:
           name: update npm
           command: "sudo npm install --unsafe-perm -g npm@latest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ version: 2.1
 
 jobs:
   build-and-test-js:
+    working_directory: ./javascript_test
     docker:
       - image: cimg/node:14.18.1
-    working_directory: ~/javascript_test
     steps:
       - checkout
       - run:
@@ -113,6 +113,7 @@ jobs:
 workflows:
   main:
     jobs:
+      - build-and-test-js
       - build-and-test
       - build-and-upload-image:
           app_name: edagames-django

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ workflows:
             - 'edagames'
       - trigger-main-repo-update:
           requires:
+            - build-and-test-js
             - build-and-test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,6 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/evbeda/edagames/dispatches \
             -d '{"event_type":"update_django"}'
-
 workflows:
   main:
     jobs:


### PR DESCRIPTION
To use CICD with Django Js files.  Add one step more in circle-ci YAML. This step reviews that if you don`t pass the Jest tests you won't make a merge. 