### PR TITLE
[EDA-1799] Filter log action by actions

### DIFF
--- a/development/common/logs_utils.py
+++ b/development/common/logs_utils.py
@@ -1,7 +1,9 @@
 
 from development.constants import (
     ALL_STATES,
-    STATE
+    ACTION,
+    ALL_ACTIONS,
+    STATE,
 )
 
 
@@ -15,3 +17,9 @@ class FilterLogs:
         possible_states = [log[STATE] for log in self.logs if STATE in log.keys()]
         possible_states.append(ALL_STATES)
         return list(set(possible_states))
+
+    @property
+    def possible_actions(self) -> list:
+        possible_actions = [log[ACTION] for log in self.logs if ACTION in log.keys()]
+        possible_actions.append(ALL_ACTIONS)
+        return list(set(possible_actions))

--- a/development/common/logs_utils.py
+++ b/development/common/logs_utils.py
@@ -1,5 +1,7 @@
 
 from development.constants import (
+    ACTION,
+    ALL_ACTIONS,
     ALL_STATES,
     ACTION,
     ALL_ACTIONS,

--- a/development/common/logs_utils.py
+++ b/development/common/logs_utils.py
@@ -1,10 +1,7 @@
-
 from development.constants import (
     ACTION,
     ALL_ACTIONS,
     ALL_STATES,
-    ACTION,
-    ALL_ACTIONS,
     STATE,
 )
 

--- a/development/constants.py
+++ b/development/constants.py
@@ -6,3 +6,10 @@ STATE = 'state'
 VALID_STATE = 'valid'
 INVALID_STATE = 'invalid'
 ALL_STATES = 'all'
+
+
+ACTION = 'action'
+MOVE_ACTION = 'MOVE'
+SHOOT_ACTION = 'SHOOT'
+WALL_ACTION = 'WALL'
+ALL_ACTIONS = 'all'

--- a/development/templates/development/match_details.html
+++ b/development/templates/development/match_details.html
@@ -5,20 +5,46 @@
     {% if data %}
     <h1>Match details 
     </h1>
-    <label for="id_of_input">Validity</label>
-    <select class="form-control" name="valid_move" id="valid_move">
-        <optgroup label="Validity">
-            {% for states in move_states %}
-            <option value="{{ states }}">{{ states|title }}</option>
-            {% endfor %}
-        </optgroup>
-    </select>
-    <input 
-    class="btn btn-primary" 
-    type="submit" 
-    value="Download as .txt" 
-    onclick="download('my_match.txt')" />
+
+    <div class="container">
+        <div class="row">
+
+          <div class="col">
+            <label for="id_of_input">Validity</label>
+            <select class="form-control" name="valid_move" id="valid_move">
+                <optgroup label="Validity">
+                    {% for states in move_states %}
+                    <option value="{{ states }}">{{ states|title }}</option>
+                    {% endfor %}
+                </optgroup>
+            </select>
+          </div>
+          <div class="col">
+            <label for="id_of_input">Kind of action</label>
+            <select class="form-control" name="valid_move" id="valid_move">
+                <optgroup label="Kind of action">
+                    {% for kind in actions_kind %}
+                    <option value="{{ kind }}">{{ kind }}</option>
+                    {% endfor %}
+                </optgroup>
+            </select>
+          </div>
+
+          <div class="col">
+            <br>
+            <input 
+                class="btn btn-primary" 
+                type="submit" 
+                value="Download as .txt" 
+                onclick="download('my_match.txt')" 
+            />
+          </div>
+
+        </div>
+      </div>
+      <br>
     {% endif %}
+
     {% if not data %}
     <h1>Match details</h1>
     {% endif %}

--- a/development/templates/development/match_details.html
+++ b/development/templates/development/match_details.html
@@ -10,7 +10,7 @@
         <div class="row">
 
           <div class="col">
-            <label for="id_of_input">Validity</label>
+            <label for="valid_move">Validity</label>
             <select class="form-control" name="valid_move" id="valid_move">
                 <optgroup label="Validity">
                     {% for states in move_states %}
@@ -20,11 +20,11 @@
             </select>
           </div>
           <div class="col">
-            <label for="id_of_input">Kind of action</label>
-            <select class="form-control" name="valid_move" id="valid_move">
+            <label for="action_kind">Kind of action</label>
+            <select class="form-control" name="valid_move" id="action_kind">
                 <optgroup label="Kind of action">
                     {% for kind in actions_kind %}
-                    <option value="{{ kind }}">{{ kind }}</option>
+                    <option value="{{ kind }}">{{ kind|title }}</option>
                     {% endfor %}
                 </optgroup>
             </select>

--- a/development/tests/log_scenarios.py
+++ b/development/tests/log_scenarios.py
@@ -48,7 +48,7 @@ def mocked_game_response(values_to_update=[]) -> dict:
     return mocked_response
 
 
-logs_test_for_validating_moves_0 = [
+logs_test_for_validating_moves_only_valid_states = [
     mocked_user_action(),
     mocked_game_response([{'state': VALID_STATE}]),
     mocked_user_action(),
@@ -69,7 +69,7 @@ logs_test_for_validating_moves_0 = [
 ]
 
 
-logs_test_for_validating_moves_1 = [
+logs_test_for_validating_moves_valid_and_invalid_state = [
     mocked_user_action(),
     mocked_game_response([{'state': VALID_STATE}]),
     mocked_user_action(),
@@ -89,7 +89,7 @@ logs_test_for_validating_moves_1 = [
     mocked_user_action(),
 ]
 
-logs_test_for_validating_moves_2 = [
+logs_test_for_validating_moves_only_invalid_states = [
     mocked_user_action(),
     mocked_game_response([{'state': INVALID_STATE}]),
     mocked_user_action(),
@@ -110,7 +110,7 @@ logs_test_for_validating_moves_2 = [
 ]
 
 
-logs_test_for_validating_moves_3 = [
+logs_test_for_validating_moves_without_log_state = [
     mocked_user_action(),
 ]
 

--- a/development/tests/log_scenarios.py
+++ b/development/tests/log_scenarios.py
@@ -1,4 +1,3 @@
-
 from development.constants import (
     ACTION,
     INVALID_STATE,
@@ -19,7 +18,8 @@ def mocked_user_action(values_to_update=[]) -> dict:
             "game_id": "",
             "turn_token": "aaaaa"
         },
-        'current_player': 'any'}
+        'current_player': 'any',
+    }
     for replace_value in values_to_update:
         mocked_action.update(replace_value)
     return mocked_action
@@ -41,7 +41,8 @@ def mocked_game_response(values_to_update=[]) -> dict:
         'side': '',
         'from_row': '',
         'from_col': '',
-        'current_player': ''}
+        'current_player': '',
+    }
     for replace_value in values_to_update:
         mocked_response.update(replace_value)
     return mocked_response
@@ -111,11 +112,10 @@ logs_test_for_validating_moves_2 = [
 
 logs_test_for_validating_moves_3 = [
     mocked_user_action(),
-
 ]
 
 
-logs_test_for_kind_of_move_0 = [
+logs_test_for_kind_of_move_action = [
     mocked_user_action([{ACTION: MOVE_ACTION}]),
     mocked_game_response(),
     mocked_user_action([{ACTION: MOVE_ACTION}]),
@@ -135,7 +135,7 @@ logs_test_for_kind_of_move_0 = [
     mocked_user_action([{ACTION: MOVE_ACTION}]),
 ]
 
-logs_test_for_kind_of_move_1 = [
+logs_test_for_kind_of_shoot_action = [
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
     mocked_game_response(),
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
@@ -145,27 +145,6 @@ logs_test_for_kind_of_move_1 = [
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
     mocked_game_response(),
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: SHOOT_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: SHOOT_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: SHOOT_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: SHOOT_ACTION}]),
-]
-
-
-logs_test_for_kind_of_move_2 = [
-    mocked_user_action([{ACTION: MOVE_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: MOVE_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: SHOOT_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: MOVE_ACTION}]),
-    mocked_game_response(),
-    mocked_user_action([{ACTION: MOVE_ACTION}]),
     mocked_game_response(),
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
     mocked_game_response(),
@@ -176,7 +155,28 @@ logs_test_for_kind_of_move_2 = [
     mocked_user_action([{ACTION: SHOOT_ACTION}]),
 ]
 
-logs_test_for_kind_of_move_3 = [
+
+logs_test_for_kind_of_move_and_shoot_actions = [
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+]
+
+logs_test_for_kind_of_move_shoot_and_wall_actions = [
     mocked_user_action([{ACTION: MOVE_ACTION}]),
     mocked_game_response(),
     mocked_user_action([{ACTION: MOVE_ACTION}]),
@@ -197,7 +197,7 @@ logs_test_for_kind_of_move_3 = [
 ]
 
 
-logs_test_for_kind_of_move_4 = [
+logs_test_for_kind_of_move_without_actions = [
     mocked_game_response(),
     mocked_game_response(),
     mocked_game_response(),

--- a/development/tests/log_scenarios.py
+++ b/development/tests/log_scenarios.py
@@ -1,7 +1,11 @@
 
 from development.constants import (
+    ACTION,
     INVALID_STATE,
-    VALID_STATE
+    MOVE_ACTION,
+    SHOOT_ACTION,
+    VALID_STATE,
+    WALL_ACTION,
 )
 
 
@@ -108,4 +112,93 @@ logs_test_for_validating_moves_2 = [
 logs_test_for_validating_moves_3 = [
     mocked_user_action(),
 
+]
+
+
+logs_test_for_kind_of_move_0 = [
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+]
+
+logs_test_for_kind_of_move_1 = [
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+]
+
+
+logs_test_for_kind_of_move_2 = [
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+]
+
+logs_test_for_kind_of_move_3 = [
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: MOVE_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: SHOOT_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: WALL_ACTION}]),
+    mocked_game_response(),
+    mocked_user_action([{ACTION: WALL_ACTION}]),
+]
+
+
+logs_test_for_kind_of_move_4 = [
+    mocked_game_response(),
+    mocked_game_response(),
+    mocked_game_response(),
 ]

--- a/development/tests/test_log_utils.py
+++ b/development/tests/test_log_utils.py
@@ -6,13 +6,26 @@ from development.common.logs_utils import FilterLogs
 from development.constants import (
     ALL_STATES,
     INVALID_STATE,
-    VALID_STATE
+    VALID_STATE,
+    ALL_ACTIONS,
+    INVALID_STATE,
+    MOVE_ACTION,
+    SHOOT_ACTION,
+    VALID_STATE,
+    ALL_STATES,
+    WALL_ACTION,
 )
 from development.tests.log_scenarios import (
     logs_test_for_validating_moves_0,
     logs_test_for_validating_moves_1,
     logs_test_for_validating_moves_2,
-    logs_test_for_validating_moves_3
+    logs_test_for_validating_moves_3,
+    logs_test_for_validating_moves_3,
+    logs_test_for_kind_of_move_0,
+    logs_test_for_kind_of_move_1,
+    logs_test_for_kind_of_move_2,
+    logs_test_for_kind_of_move_3,
+    logs_test_for_kind_of_move_4,
 )
 
 
@@ -40,3 +53,16 @@ class TestFilterLogs(TestCase):
         self.assertEqual(
             sorted(possible_states),
             sorted(expected_possible_states))
+
+    @parameterized.expand([
+        (logs_test_for_kind_of_move_0, [MOVE_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_1, [SHOOT_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_2, [MOVE_ACTION, SHOOT_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_3, [MOVE_ACTION, SHOOT_ACTION, WALL_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_4, [ALL_ACTIONS]),
+    ])
+    def test_getting_possible_log_action(self, data, expected_possible_actions):
+        possible_actions = FilterLogs(data).possible_actions
+        self.assertEqual(
+            sorted(possible_actions),
+            sorted(expected_possible_actions))

--- a/development/tests/test_log_utils.py
+++ b/development/tests/test_log_utils.py
@@ -17,30 +17,30 @@ from development.tests.log_scenarios import (
     logs_test_for_kind_of_move_and_shoot_actions,
     logs_test_for_kind_of_move_shoot_and_wall_actions,
     logs_test_for_kind_of_move_without_actions,
-    logs_test_for_validating_moves_0,
-    logs_test_for_validating_moves_1,
-    logs_test_for_validating_moves_2,
-    logs_test_for_validating_moves_3,
+    logs_test_for_validating_moves_only_valid_states,
+    logs_test_for_validating_moves_valid_and_invalid_state,
+    logs_test_for_validating_moves_only_invalid_states,
+    logs_test_for_validating_moves_without_log_state,
 )
 
 
 class TestFilterLogs(TestCase):
 
     @parameterized.expand([
-        (logs_test_for_validating_moves_0,),
-        (logs_test_for_validating_moves_1,),
-        (logs_test_for_validating_moves_2,),
-        (logs_test_for_validating_moves_3,),
+        (logs_test_for_validating_moves_only_valid_states,),
+        (logs_test_for_validating_moves_valid_and_invalid_state,),
+        (logs_test_for_validating_moves_only_invalid_states,),
+        (logs_test_for_validating_moves_without_log_state,),
     ])
     def test_correct_FilterLogs_intance_creation(self, data):
         filter_logs = FilterLogs(data)
         self.assertEqual(filter_logs.logs, data)
 
     @parameterized.expand([
-        (logs_test_for_validating_moves_0, [VALID_STATE, ALL_STATES]),
-        (logs_test_for_validating_moves_1, [VALID_STATE, INVALID_STATE, ALL_STATES]),
-        (logs_test_for_validating_moves_2, [INVALID_STATE, ALL_STATES]),
-        (logs_test_for_validating_moves_3, [ALL_STATES]),
+        (logs_test_for_validating_moves_only_valid_states, [VALID_STATE, ALL_STATES]),
+        (logs_test_for_validating_moves_valid_and_invalid_state, [VALID_STATE, INVALID_STATE, ALL_STATES]),
+        (logs_test_for_validating_moves_only_invalid_states, [INVALID_STATE, ALL_STATES]),
+        (logs_test_for_validating_moves_without_log_state, [ALL_STATES]),
     ])
     def test_getting_possible_log_actions_states(self, data, expected_possible_states):
         possible_states = FilterLogs(data).possible_states

--- a/development/tests/test_log_utils.py
+++ b/development/tests/test_log_utils.py
@@ -1,31 +1,26 @@
-
 from django.test import TestCase
 from parameterized import parameterized
 
 from development.common.logs_utils import FilterLogs
 from development.constants import (
-    ALL_STATES,
-    INVALID_STATE,
-    VALID_STATE,
     ALL_ACTIONS,
+    ALL_STATES,
     INVALID_STATE,
     MOVE_ACTION,
     SHOOT_ACTION,
     VALID_STATE,
-    ALL_STATES,
     WALL_ACTION,
 )
 from development.tests.log_scenarios import (
+    logs_test_for_kind_of_move_action,
+    logs_test_for_kind_of_shoot_action,
+    logs_test_for_kind_of_move_and_shoot_actions,
+    logs_test_for_kind_of_move_shoot_and_wall_actions,
+    logs_test_for_kind_of_move_without_actions,
     logs_test_for_validating_moves_0,
     logs_test_for_validating_moves_1,
     logs_test_for_validating_moves_2,
     logs_test_for_validating_moves_3,
-    logs_test_for_validating_moves_3,
-    logs_test_for_kind_of_move_0,
-    logs_test_for_kind_of_move_1,
-    logs_test_for_kind_of_move_2,
-    logs_test_for_kind_of_move_3,
-    logs_test_for_kind_of_move_4,
 )
 
 
@@ -38,7 +33,6 @@ class TestFilterLogs(TestCase):
         (logs_test_for_validating_moves_3,),
     ])
     def test_correct_FilterLogs_intance_creation(self, data):
-
         filter_logs = FilterLogs(data)
         self.assertEqual(filter_logs.logs, data)
 
@@ -52,17 +46,19 @@ class TestFilterLogs(TestCase):
         possible_states = FilterLogs(data).possible_states
         self.assertEqual(
             sorted(possible_states),
-            sorted(expected_possible_states))
+            sorted(expected_possible_states)
+        )
 
     @parameterized.expand([
-        (logs_test_for_kind_of_move_0, [MOVE_ACTION, ALL_ACTIONS]),
-        (logs_test_for_kind_of_move_1, [SHOOT_ACTION, ALL_ACTIONS]),
-        (logs_test_for_kind_of_move_2, [MOVE_ACTION, SHOOT_ACTION, ALL_ACTIONS]),
-        (logs_test_for_kind_of_move_3, [MOVE_ACTION, SHOOT_ACTION, WALL_ACTION, ALL_ACTIONS]),
-        (logs_test_for_kind_of_move_4, [ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_action, [MOVE_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_shoot_action, [SHOOT_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_and_shoot_actions, [MOVE_ACTION, SHOOT_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_shoot_and_wall_actions, [MOVE_ACTION, SHOOT_ACTION, WALL_ACTION, ALL_ACTIONS]),
+        (logs_test_for_kind_of_move_without_actions, [ALL_ACTIONS]),
     ])
     def test_getting_possible_log_action(self, data, expected_possible_actions):
         possible_actions = FilterLogs(data).possible_actions
         self.assertEqual(
             sorted(possible_actions),
-            sorted(expected_possible_actions))
+            sorted(expected_possible_actions)
+        )

--- a/development/tests/test_match_details.py
+++ b/development/tests/test_match_details.py
@@ -1,19 +1,25 @@
 from unittest.mock import (
-    MagicMock,
-    patch
+    patch,
+    PropertyMock,
 )
 
-from unittest.mock import PropertyMock, patch
-from parameterized import parameterized
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from parameterized import parameterized
 
 from auth_app.models import Bot
 from development.common.logs_utils import FilterLogs
-from development.constants import ALL_ACTIONS, ALL_STATES, INVALID_STATE, MOVE_ACTION, SHOOT_ACTION, VALID_STATE
+from development.constants import (
+    ALL_ACTIONS,
+    ALL_STATES,
+    INVALID_STATE,
+    MOVE_ACTION,
+    SHOOT_ACTION,
+    VALID_STATE,
+)
 from development.models import (
     Match,
-    MatchMembers
+    MatchMembers,
 )
 
 
@@ -94,8 +100,8 @@ class TestMatchDetailsView(TestCase):
     @patch.object(FilterLogs, 'possible_actions', new_callable=PropertyMock)
     def test_should_shows_pass_data_to_template_when_it_is_received_from_server(
         self,
-        mokced_possible_action,
-        mokced_possible_states,
+        mocked_possible_action,
+        mocked_possible_states,
         mocked_generate_text,
         mocked_get_log,
     ):
@@ -156,15 +162,14 @@ class TestMatchDetailsView(TestCase):
         self,
         possible_states,
         possible_actions,
-
-        mokced_possible_action,
-        mokced_possible_states,
+        mocked_possible_action,
+        mocked_possible_states,
         mocked_generate_text,
         mocked_get_log,
     ):
 
-        mokced_possible_action.return_value = possible_actions
-        mokced_possible_states.return_value = possible_states
+        mocked_possible_action.return_value = possible_actions
+        mocked_possible_states.return_value = possible_states
 
         response = self.client.get(f'/match_details/{self.user1.id}?page=1')
 

--- a/development/tests/test_match_details.py
+++ b/development/tests/test_match_details.py
@@ -3,16 +3,14 @@ from unittest.mock import (
     patch
 )
 
+from unittest.mock import PropertyMock, patch
+from parameterized import parameterized
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from auth_app.models import Bot
 from development.common.logs_utils import FilterLogs
-from development.constants import (
-    ALL_STATES,
-    INVALID_STATE,
-    VALID_STATE
-)
+from development.constants import ALL_ACTIONS, ALL_STATES, INVALID_STATE, MOVE_ACTION, SHOOT_ACTION, VALID_STATE
 from development.models import (
     Match,
     MatchMembers
@@ -90,14 +88,16 @@ class TestMatchDetailsView(TestCase):
         response = self.client.get(f'/match_details/{self.user1.id}?page=1')
         self.assertEquals(response.context_data['object'].id, self.match.id)
 
-    @patch.object(FilterLogs, 'possible_states')
     @patch('development.views.get_logs')
     @patch('development.views.generate_text')
+    @patch.object(FilterLogs, 'possible_states', new_callable=PropertyMock)
+    @patch.object(FilterLogs, 'possible_actions', new_callable=PropertyMock)
     def test_should_shows_pass_data_to_template_when_it_is_received_from_server(
         self,
-        mocked_get_log,
+        mokced_possible_action,
+        mokced_possible_states,
         mocked_generate_text,
-        _,
+        mocked_get_log,
     ):
         return_value = {
             "details": "testing",
@@ -109,9 +109,10 @@ class TestMatchDetailsView(TestCase):
             "prev": None,
             "next": "asdqweu12391823uiwjkdnsamd"
         }
+
         mocked_get_log.return_value = return_value
         mocked_generate_text.return_value = return_value
-        _ = MagicMock(return_value=[INVALID_STATE, VALID_STATE, ALL_STATES])
+
         response = self.client.get(f'/match_details/{self.user1.id}?page=1')
         self.assertEquals(
             response.context_data['data'],
@@ -141,4 +142,37 @@ class TestMatchDetailsView(TestCase):
         self.assertEquals(
             response.context_data['data'],
             "testing"
+        )
+
+    @parameterized.expand([
+        ([INVALID_STATE, VALID_STATE, ALL_STATES], [ALL_ACTIONS],),
+        ([VALID_STATE, ALL_STATES], [MOVE_ACTION, SHOOT_ACTION, ALL_ACTIONS],),
+    ])
+    @patch('development.views.get_logs')
+    @patch('development.views.generate_text')
+    @patch.object(FilterLogs, 'possible_states', new_callable=PropertyMock)
+    @patch.object(FilterLogs, 'possible_actions', new_callable=PropertyMock)
+    def test_should_shows_filter_logs_options_to_template_when_it_is_received_from_server(
+        self,
+        possible_states,
+        possible_actions,
+
+        mokced_possible_action,
+        mokced_possible_states,
+        mocked_generate_text,
+        mocked_get_log,
+    ):
+
+        mokced_possible_action.return_value = possible_actions
+        mokced_possible_states.return_value = possible_states
+
+        response = self.client.get(f'/match_details/{self.user1.id}?page=1')
+
+        self.assertEquals(
+            response.context_data['move_states'],
+            possible_states
+        )
+        self.assertEquals(
+            response.context_data['actions_kind'],
+            possible_actions
         )

--- a/development/views.py
+++ b/development/views.py
@@ -82,9 +82,12 @@ class MatchDetailsView(DetailView):
         ).get_context_data(**kwargs)
 
         data = response['details']
-        move_states = FilterLogs(data).possible_states
+        filter_logs = FilterLogs(data)
+        move_states = filter_logs.possible_states
+        actions_kind = filter_logs.possible_actions
 
         context['move_states'] = move_states
+        context['actions_kind'] = actions_kind
         context['data'] = data
         context['prev_page'] = response['prev']
         context['next_page'] = response['next']


### PR DESCRIPTION
I add the filter to the kind of action of the logs.
For this, I add a property `possible_actions`

I add the `select` dropdown to the template and refactor it a little bit with bootstrap col and rows to  give it a pretty look

<img width="1609" alt="image" src="https://user-images.githubusercontent.com/113444840/197568735-59fc6ec5-f88a-429f-b6a7-73b504122680.png">

When a User click the drop he sees the following

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/113444840/197568810-fc19e941-1bff-4f54-b9b0-54387805752f.png">


I add a test `test_should_shows_filter_logs_options_to_template_when_it_is_received_from_server` to test if the Django View tit's actually rendering the options correctly


> ❗️❗️ This PR MUST not be merged until the [Previous PR](https://github.com/evbeda/edagames-django/pull/188) has been merged
