### PR TITLE
[EDA-1798][Minor]Add debug mode

### DIFF
--- a/development/forms.py
+++ b/development/forms.py
@@ -1,11 +1,13 @@
-from django import forms
-from .bot_handler import (
-    get_users_data,
-    get_online_bots,
-    get_my_bots,
-)
-from auth_app.models import Bot
 import re
+
+from django import forms
+
+from auth_app.models import Bot
+from .bot_handler import (
+    get_my_bots,
+    get_online_bots,
+    get_users_data,
+)
 
 
 class ChallengeForm(forms.Form):
@@ -21,6 +23,7 @@ class ChallengeForm(forms.Form):
 
     bot1 = forms.ChoiceField(label='MyBots', widget=forms.Select, choices=[])
     bot2 = forms.ChoiceField(label='Online Bots', widget=forms.Select, choices=[])
+    debug_mode = forms.BooleanField(label='Debug Mode', required=False, initial=False,)
 
 
 class BotForm(forms.ModelForm):

--- a/development/server_requests.py
+++ b/development/server_requests.py
@@ -1,17 +1,21 @@
-from edagames import settings
-import requests
 from typing import List
+
+import requests
+
+from edagames import settings
 
 
 def send_challenge(
     challenger: str,
     challenged: List[str],
     tournament_id: str = '',
+    debug_mode: bool = False,
 ):
     data = {
         "challenger": challenger,
         "challenged": challenged,
         "tournament_id": tournament_id,
+        "debug_mode": debug_mode,
     }
     return requests.post(
         f'{settings.SERVER_URL}:{settings.SERVER_PORT}/challenge',

--- a/development/tests/test_server_requests.py
+++ b/development/tests/test_server_requests.py
@@ -1,11 +1,16 @@
+import json
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
 from django.test import TestCase
-from unittest.mock import patch
+from parameterized import parameterized
+
 from development.server_requests import (
     get_logs,
     send_challenge,
 )
-import json
-from unittest.mock import MagicMock
 from edagames.settings import (
     SERVER_PORT,
     SERVER_URL,
@@ -14,9 +19,16 @@ from edagames.settings import (
 
 class TestServerRequests(TestCase):
 
-    def test_send_challenge(self):
+    @parameterized.expand(
+        [
+            ('debug_mode_enable', True, ),
+            ('debug_mode_disable', False, ),
+        ]
+    )
+    def test_send_challenge(self, name, debug_mode):
         test_player1 = 'test_player1'
         test_player2 = ['test_player2']
+        debug_mode = debug_mode
         mocked_response = MagicMock(json=lambda x: json.loads(x), spec=["json"])
         with patch(
             'requests.post',
@@ -25,6 +37,7 @@ class TestServerRequests(TestCase):
             send_challenge(
                 test_player1,
                 test_player2,
+                debug_mode=debug_mode,
             )
             request_get_mocked.assert_called_once_with(
                 f'{SERVER_URL}:{SERVER_PORT}/challenge',
@@ -32,6 +45,7 @@ class TestServerRequests(TestCase):
                     'challenger': test_player1,
                     'challenged': test_player2,
                     'tournament_id': '',
+                    'debug_mode': debug_mode,
                 }
             )
 

--- a/development/tests/test_views_forms.py
+++ b/development/tests/test_views_forms.py
@@ -1,14 +1,18 @@
-from auth_app.models import User, Bot
+from unittest.mock import patch
+
+from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
+from parameterized import parameterized
+
 from ..views import (
     AddBotView,
     ChallengeView,
     MatchListView,
     MyBotsView,
 )
+
+from auth_app.models import User, Bot
 from ..forms import ChallengeForm
-from unittest.mock import patch
-from django.http import HttpResponse
 
 
 class TestView(TestCase):
@@ -31,11 +35,17 @@ class TestView(TestCase):
         response = ChallengeView.as_view()(request)
         self.assertEqual(response.status_code, 200)
 
+    @parameterized.expand(
+        [
+            ('with_debug_mode_enable', True,),
+            ('with_debug_mode_disable', False,),
+        ]
+    )
     @patch('development.views.messages')
     @patch('requests.post')
-    def test_form_valid(self, post_patched, messages_patched):
+    def test_form_valid(self, name, debug_mode, post_patched, messages_patched):
         post_patched.return_value = HttpResponse(status=200)
-        form = ChallengeForm({'bot1': '0', 'bot2': '1'})
+        form = ChallengeForm({'bot1': '0', 'bot2': '1', 'debug_mode': debug_mode})
         form.fields['bot1'].choices = [(0, 'bot1')]
         form.fields['bot2'].choices = [(0, 'bot1'), (1, 'bot2')]
         form.is_valid()

--- a/development/views.py
+++ b/development/views.py
@@ -1,27 +1,27 @@
 from django.contrib import messages
-from django.views.decorators.http import require_http_methods
-from django.views.generic.edit import FormView
-from django.views.generic.detail import DetailView
-from django.views.generic.list import ListView
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
+from django.views.decorators.http import require_http_methods
+from django.views.generic.detail import DetailView
+from django.views.generic.edit import FormView
+from django.views.generic.list import ListView
 
 from auth_app.models import Bot
 from development.common.logs_utils import FilterLogs
-from .common.match_utils import (
-    get_matches_of_connected_user,
-    get_matches_results,
-)
-from .common.match_result_text import generate_text
 from development.forms import ChallengeForm
 from development.server_requests import (
     get_logs,
     send_challenge,
 )
+from .common.match_result_text import generate_text
+from .common.match_utils import (
+    get_matches_of_connected_user,
+    get_matches_results,
+)
 from .encode_jwt import encode_data
+from .forms import BotForm
 from .models import Match
 from .tables import BotTable
-from .forms import BotForm
 
 
 class ChallengeView(FormView):
@@ -43,11 +43,13 @@ class ChallengeView(FormView):
         option2 = int(form.cleaned_data['bot2'])
         bot1 = dict(form.fields['bot1'].choices)[option1]
         bot2 = dict(form.fields['bot2'].choices)[option2]
+        debug_mode = bool(form.cleaned_data['debug_mode'])
 
         response = send_challenge(
             challenger=f"{bot1}",
             challenged=[f"{bot2}"],
             tournament_id="",
+            debug_mode=debug_mode
         )
         if response.status_code == 200:
             messages.add_message(


### PR DESCRIPTION
The debug mode has been added to the challenge creation. This mode setups the timeout time for each play that the user bots make. So now, the user can choose to play a normal challenge, with a normal timeout(currently set in 15s, in the server) or with a debug timeout(set in 60s).
In order to add this feature, I had to modify the following parts of the Django app code:
	•	A debug_mode attribute was added to the ChallengeForm
	•	In order to process this form by the ChallengeView, it has to be modified too. Specifically in the form_valid() overriding method
	•	The send_challenge() function was modified to accept the debug_mode parameter
