### PR TITLE
finalist in championship now are retrieved correctly

### DIFF
--- a/tournaments/common/tournament_utils.py
+++ b/tournaments/common/tournament_utils.py
@@ -96,15 +96,20 @@ def get_finalist_users(champ: Championship, max_bot_finalist: int):
     # get list of all bots that had been in the tournaments
     bot_that_participated = []
     for tournament in tournaments_list:
-        bot_that_participated.extend(
+        if 'FINAL' in tournament.name:
+            continue
+        bot_that_participated.append(
             sort_position_table(
                 get_tournament_results(
                     tournament.id)))
 
     # get the first n bots
-    top_bots = bot_that_participated[:max_bot_finalist]
+    finalist = []
+    for bots_per_tournament in bot_that_participated:
+        for x in range(max_bot_finalist):
+            finalist.append(tuple(bots_per_tournament[x]))
     finalist_users = []
-    for bot in top_bots:
+    for bot in finalist:
         user = User.objects.get(email=bot[0])
         finalist_users.append(user)
     return finalist_users

--- a/tournaments/templates/tournaments/championship_list.html
+++ b/tournaments/templates/tournaments/championship_list.html
@@ -10,6 +10,7 @@
           <th scope="col">Name</th>
           <th scope="col">Final Tournament</th>
           <th scope="col"></th>
+          <th scope="col">Date</th>
         </tr>
       </thead>
       <tbody>
@@ -24,6 +25,7 @@
               <input type="submit" class="btn btn-primary" value="View finalist users">
             </form>
           </td>
+          <td>{{ championship.final_tournament.date_tournament }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tournaments/tests/test_final_tournament.py
+++ b/tournaments/tests/test_final_tournament.py
@@ -194,7 +194,7 @@ class TestFinalistUserView(TestCase):
         self.user.is_staff = True
         self.client.force_login(self.user)
         self.view = FinalistUserView()
-        self.final_tournament = Tournament.objects.create(name="final-test-3")
+        self.final_tournament = Tournament.objects.create(name="FINAL-test-3")
         self.championship = Championship.objects.create(
             name="champ-test-3",
             tournament_bots=3,


### PR DESCRIPTION
previous to this PR, the list of finalist users only retrieve the finalist of just one tournament, now displays the finalist of all tournaments associated with a championship

also, added the date column in the championship history template